### PR TITLE
Add permissive CORS to the gateway so browsers can hit OTP routes

### DIFF
--- a/server/src/Gateway/Program.cs
+++ b/server/src/Gateway/Program.cs
@@ -26,6 +26,24 @@ builder.Services.AddControllers()
 builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
 
+// Permissive CORS so the planner web build (browser) can call OTP
+// 1.5 / OTP 2.8 endpoints proxied through this gateway. Without
+// this, browsers block cross-origin XHR with "No
+// Access-Control-Allow-Origin header" because OTP itself doesn't
+// emit CORS headers and YARP doesn't add them either. The Trufi
+// Planner remote (`/api`) emits CORS itself, which is why that one
+// already worked from the web — only the OTP-backed routes needed
+// help.
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+
 // Let's Encrypt (only in production)
 if (!builder.Environment.IsDevelopment())
 {
@@ -62,6 +80,8 @@ app.UseMiddleware<AnalyticsMiddleware>();
 
 // Map controllers (Analytics API endpoints)
 app.MapControllers();
+
+app.UseCors();
 
 // YARP reverse proxy
 app.MapReverseProxy();


### PR DESCRIPTION
## Summary

The gateway proxies `otp150.trufi.app` and `otp281.trufi.app` to the OTP containers, but neither OTP itself nor YARP add `Access-Control-Allow-Origin` to the responses. Any browser-side caller — notably `planner.trufi.app`'s web build — saw `Failed to fetch` on OTP-backed plan requests, because the browser blocked the cross-origin XHR.

`/api` (the Trufi Planner remote) emits CORS in the upstream service, which is why that cluster always worked from the same browsers — only OTP needed help.

## Change

- Register a permissive CORS policy on the gateway (`AllowAnyOrigin / AllowAnyMethod / AllowAnyHeader`).
- Call `app.UseCors()` before `app.MapReverseProxy()` so the middleware can add the headers (and answer OPTIONS preflights with `204`) uniformly across every proxied response, including OTP.

If we later want to tighten this, we can replace the default policy with one that allows only the production planner origin(s).

## Test plan

- [x] Built the container (`docker compose build server`) and restarted it on prod (`143.198.77.246`).
- [x] `curl -I -X OPTIONS -H "Origin: https://planner.trufi.app" "https://otp150.trufi.app/otp/routers/default/plan?fromPlace=…&toPlace=…"` → `HTTP/2 204`, `access-control-allow-origin: *`.
- [x] `curl -I -H "Origin: https://planner.trufi.app" "https://otp150.trufi.app/otp/routers/default/plan?…"` → `HTTP/2 200`, `access-control-allow-origin: *`.
- [x] `planner.trufi.app` returns plans when OTP 1.5 / OTP 2.8 is the selected engine (regression test for the original issue).