### PR TITLE
fix(healthcheck): use curl against /health instead of bash-only /dev/tcp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,11 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "cat < /dev/tcp/localhost/80 || exit 1"]
+      test: ["CMD", "curl", "--fail", "--silent", "--max-time", "5", "-o", "/dev/null", "http://localhost/health"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 30s
 
   db:
     image: postgres:16-alpine

--- a/server/src/Gateway/Dockerfile
+++ b/server/src/Gateway/Dockerfile
@@ -20,6 +20,9 @@ RUN dotnet publish -c Release -o /app
 # Runtime
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview
 WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app .
 EXPOSE 80 443
 ENTRYPOINT ["dotnet", "Gateway.dll"]


### PR DESCRIPTION
## Summary
- Replace the broken bash-only `cat < /dev/tcp/localhost/80` healthcheck with `curl --fail http://localhost/health`.
- Install `curl` in the runtime image (no HTTP client was available before).
- Bump `start_period` to `30s` so cold starts don't trip retries.

## Why

The current healthcheck has been failing **every single invocation since it was introduced** (FailingStreak observed in production: ~57,000 consecutive failures over weeks). The actual error captured from `docker inspect`:

```
/bin/sh: 1: cannot open /dev/tcp/localhost/80: No such file
```

`/dev/tcp/host/port` is a **bash-only feature**. The runtime image `mcr.microsoft.com/dotnet/aspnet:10.0-preview` symlinks `/bin/sh` to `dash`, which does not implement it. The check fails immediately, regardless of whether the gateway is healthy.

Verified live:
- `curl http://localhost/` → `HTTP 404` (root has no route — expected for an API gateway)
- `curl http://localhost/health` → `HTTP 200` (built-in ASP.NET Core health endpoint works fine)

So the gateway has been healthy all along; only the check was wrong.

## Test plan
- [ ] Pull and `docker compose up -d --build` on the host.
- [ ] `docker inspect --format '{{.State.Health.Status}}' server-server-1` reports `healthy` after `start_period + interval`.
- [ ] `docker inspect ... | jq '.State.Health.Log[-1]'` shows ExitCode `0`.
- [ ] Existing traffic on :80/:443 keeps responding (no regression).