### PR TITLE
fix(cert): persist LettuceEncrypt cert across container rebuilds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - ./data/certificates:/root/.aspnet/https
       - ./data/lettuce-encrypt:/etc/lettuce-encrypt
+      - ./data/dotnet-x509:/root/.dotnet/corefx/cryptography
       - ./data/config/appsettings.json:/app/appsettings.json:ro
     depends_on:
       db:


### PR DESCRIPTION
## Summary
Add a volume mount for the directory where LettuceEncrypt actually stores its certificate, so it survives container rebuilds.

## What's broken today

The configured `CertificateStoragePath: /etc/lettuce-encrypt` (set by `setup.sh`) is **not honored** by LettuceEncrypt — most likely because `PfxPassword` is unset, which the `FileSystemCertificateRepository` requires to persist PFX files. So LE falls back to the default .NET `X509Store`, which on Linux lives at:

```
/root/.dotnet/corefx/cryptography/x509stores/my/<thumbprint>.pfx
```

That path is **inside the container's ephemeral filesystem** (no volume mount), so:

- `docker restart` ✅ keeps the cert (only the process is restarted).
- `docker compose down` / `up --build` ❌ destroys the container and the cert with it.

After a rebuild, LE has to re-issue certs for all 6 configured domains. Let's Encrypt has a **5 duplicate-certs per week per domain set** rate limit; doing several rebuilds in a short window can trigger it and break HTTPS until the limit clears.

This was verified live on prod:
- `find / -name "*.pfx"` inside the running container returned exactly the path above.
- The currently-served cert (LE, valid until 2026-08-06) lives only there — `./data/lettuce-encrypt/` and `./data/certificates/` on the host are both empty.

## Fix
Mount the actual storage path so the cert persists across rebuilds:

```diff
     volumes:
       - ./data/certificates:/root/.aspnet/https
       - ./data/lettuce-encrypt:/etc/lettuce-encrypt
+      - ./data/dotnet-x509:/root/.dotnet/corefx/cryptography
       - ./data/config/appsettings.json:/app/appsettings.json:ro
```

The two pre-existing mounts are kept untouched — they're harmless (empty dirs in practice) and removing them is out of scope here.

## Deploy notes (important)

On first deploy with this change, `./data/dotnet-x509/` will be empty, so LE will re-issue certs once (1 request to LE for all 6 domains). Below the rate limit, so fine.

**To avoid even that single re-issuance**, the live cert can be copied from the running container before the rebuild:

```bash
mkdir -p /root/server/data/dotnet-x509
docker cp server-server-1:/root/.dotnet/corefx/cryptography/. \
  /root/server/data/dotnet-x509/
chmod -R 700 /root/server/data/dotnet-x509
docker compose up -d --force-recreate
```

After that, future rebuilds will pick up the persisted cert without contacting LE at all (until it gets close to expiry and LE renews normally).

## Test plan
- [ ] `docker compose up -d` after applying.
- [ ] `ls /root/server/data/dotnet-x509/x509stores/my/` contains the `.pfx` of the cert.
- [ ] `openssl s_client -connect <domain>:443` returns the same cert as before (or a freshly-issued one if we did not pre-copy).
- [ ] Stop and start the container a couple of times; cert files persist on host, no new LE requests in logs.